### PR TITLE
Update train.py

### DIFF
--- a/pointcept/engines/train.py
+++ b/pointcept/engines/train.py
@@ -70,6 +70,7 @@ class TrainerBase:
                 # => after epoch
                 self.after_epoch()
             # => after train
+            comm.synchronize()
             self.after_train()
 
     def before_train(self):


### PR DESCRIPTION
Synchronize before starting PreciseEvaluator to wait the main process to save the model parameters, which can prevent the other processes to load the old model parameters.