### PR TITLE
Fix Pop key "name" from "data_dict"  on NuScenes dataset

### DIFF
--- a/pointcept/datasets/nuscenes.py
+++ b/pointcept/datasets/nuscenes.py
@@ -74,7 +74,12 @@ class NuScenesDataset(DefaultDataset):
             )
         else:
             segment = np.ones((points.shape[0],), dtype=np.int64) * self.ignore_index
-        data_dict = dict(coord=coord, strength=strength, segment=segment, name=self.get_data_name(idx))
+        data_dict = dict(
+            coord=coord,
+            strength=strength,
+            segment=segment,
+            name=self.get_data_name(idx),
+        )
         return data_dict
 
     def get_data_name(self, idx):

--- a/pointcept/datasets/nuscenes.py
+++ b/pointcept/datasets/nuscenes.py
@@ -74,7 +74,7 @@ class NuScenesDataset(DefaultDataset):
             )
         else:
             segment = np.ones((points.shape[0],), dtype=np.int64) * self.ignore_index
-        data_dict = dict(coord=coord, strength=strength, segment=segment)
+        data_dict = dict(coord=coord, strength=strength, segment=segment, name=self.get_data_name(idx))
         return data_dict
 
     def get_data_name(self, idx):


### PR DESCRIPTION
There is an issue when testing on NuScenes dataset. Method get_data from NuScenesDataset does not return a dict with the key "name" in it.

This key is needed when performing method prepare_test_data from DefaultDataset.

https://github.com/Pointcept/Pointcept/blob/bd13c1eaecf7876c1b90d61284c24392df446ce9/pointcept/datasets/defaults.py#L139

This PR intends to solve this issue