### PR TITLE
Add Weights & Biases Support

### DIFF
--- a/pointcept/utils/writer.py
+++ b/pointcept/utils/writer.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Union
 from tensorboardX import SummaryWriter
 
-from pointcept.utils.logger import get_root_logger
 from pointcept.utils.config import Config
 
 
@@ -32,8 +31,6 @@ class ExperimentWriter(object):
             wandb_name (str, optional): wandb run name, if not set, inferred from save_path. Defaults to None.
             wandb_id (str, optional): Set this to continue logging to a run / overwrite a run. Defaults to None.
         """
-        self.logger = get_root_logger()
-
         assert (
             use_tensorboard or use_wandb
         ), "At least one of use_tensorboard or use_wandb must be True."

--- a/pointcept/utils/writer.py
+++ b/pointcept/utils/writer.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from typing import Union
+from tensorboardX import SummaryWriter
+
+from pointcept.utils.logger import get_root_logger
+from pointcept.utils.config import Config
+
+
+class ExperimentWriter(object):
+    def __init__(
+        self,
+        save_path: Union[str, Path],
+        use_tensorboard: bool = True,
+        use_wandb: bool = False,
+        wandb_project: str = None,
+        wandb_entity: str = None,
+        wandb_config: Union[dict, Config] = None,
+        wandb_group: str = None,
+        wandb_name: str = None,
+        wandb_id: str = None,
+    ):
+        """Abstraction over the TensorBoard writer or wandb logger.
+
+        Args:
+            save_path (str | Path): Path to save the local experiment logs.
+            use_tensorboard (bool, optional): Whether to use tensorboard. Defaults to True.
+            use_wandb (bool, optional): Whether to use Weights & Biases. Defaults to False.
+            wandb_project (str, optional): wandb project name. Defaults to None.
+            wandb_entity (str, optional): wandb entity name. Defaults to None.
+            wandb_config (dict, optional): hyperparameter config to log for the run. Defaults to None.
+            wandb_group (str, optional): wandb group name. Defaults to None.
+            wandb_name (str, optional): wandb run name, if not set, inferred from save_path. Defaults to None.
+            wandb_id (str, optional): Set this to continue logging to a run / overwrite a run. Defaults to None.
+        """
+        self.logger = get_root_logger()
+
+        assert (
+            use_tensorboard or use_wandb
+        ), "At least one of use_tensorboard or use_wandb must be True."
+        if use_wandb:
+            assert wandb_project, "wandb_project is required for logging to wandb."
+
+        self.wandb = None
+        if use_wandb:
+            try:
+                import wandb
+
+                assert wandb_project, "wandb_project is required for logging to wandb."
+                wandb.init(
+                    project=wandb_project,
+                    entity=wandb_entity,
+                    config=wandb_config,
+                    group=wandb_group,
+                    name=wandb_name if wandb_name else Path(save_path).name,
+                    dir=save_path,
+                    id=wandb_id,
+                )
+                self.wandb = wandb
+            except ImportError:
+                raise Exception("Tried to use wandb logger but wandb is not installed.")
+
+        self.tb_writer = None
+        if use_tensorboard:
+            self.tb_writer = SummaryWriter(save_path)
+
+    def add_scalar(self, tag: str, val: float, step: float = None):
+        if self.wandb:
+            self.wandb.log({tag: val}, step=step)
+        if self.tb_writer:
+            self.tb_writer.add_scalar(tag, val, step)
+
+    def close(self):
+        if self.wandb:
+            self.wandb.finish()
+        if self.tb_writer:
+            self.tb_writer.close()


### PR DESCRIPTION
Hi all,

this PR adds support to log experiments to Weights & Biases in addition to Tensorboard.

Advantages of wandb include:
- Overlaying training and validation curves in a single plot
- Filtering experiments by hyperparameters
- Automatic logging of system metrics such as GPU usage

To enable wandb logging:
- Install wandb: `pip install wandb`
- Log into wandb: `wandb login`
- Add the following to any config file:
  ```python
  # ...
  wandb = dict(
      use_wandb=True,
      project="[WANDB-PROJECT-NAME]",
      entity="[WANDB-ENTITY-NAME]",
      group=None,
      id=None,
  )
  # ...
  ```

The wandb module is only imported if wandb logging is enabled in the config, so `wandb` is an optional dependency and existing code should not break.

The abstract writer object is written such that wandb can also fully replace tensorboard to avoid redundancy, but I've decided to not pass that option through to the user yet. (Tensorboard logging is hardcoded to True in `build_writer` of `pointcept/engines/train.py`.)

Attention: Due to time constraints I did **not** add a wandb EventWriter to `pointcept/utils/events.py` yet.

If you have any questions don't hesitate to contact me! :)