### PR TITLE
Set dtype for function np.ones

### DIFF
--- a/pointcept/datasets/defaults.py
+++ b/pointcept/datasets/defaults.py
@@ -194,7 +194,8 @@ class ConcatDataset(Dataset):
         for i in range(len(self.datasets)):
             data_list.extend(
                 zip(
-                    np.ones(len(self.datasets[i]), dtype=int) * i, np.arange(len(self.datasets[i]))
+                    np.ones(len(self.datasets[i]), dtype=int) * i,
+                    np.arange(len(self.datasets[i])),
                 )
             )
         return data_list

--- a/pointcept/datasets/defaults.py
+++ b/pointcept/datasets/defaults.py
@@ -194,7 +194,7 @@ class ConcatDataset(Dataset):
         for i in range(len(self.datasets)):
             data_list.extend(
                 zip(
-                    np.ones(len(self.datasets[i])) * i, np.arange(len(self.datasets[i]))
+                    np.ones(len(self.datasets[i]), dtype=int) * i, np.arange(len(self.datasets[i]))
                 )
             )
         return data_list


### PR DESCRIPTION
The default dtype is float64. However, since we are using this variable as indices, we need int.

This PR solves issue #403.