### PR TITLE
Semantic Segmentation Train Evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ outputs/
 */.DS_Store
 **/*.out
 Dockerfile
+wandb

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ The preprocessing supports semantic and instance segmentation for both `ScanNet2
   python pointcept/datasets/preprocessing/sampling_chunking_data.py --dataset_root ${PROCESSED_SCANNETPP_DIR} --grid_size 0.01 --chunk_range 6 6 --chunk_stride 3 3 --split train --num_workers ${NUM_WORKERS}
   python pointcept/datasets/preprocessing/sampling_chunking_data.py --dataset_root ${PROCESSED_SCANNETPP_DIR} --grid_size 0.01 --chunk_range 6 6 --chunk_stride 3 3 --split val --num_workers ${NUM_WORKERS}
   ```
-- (Alternative) Our preprocess data can be directly downloaded [[here](https://huggingface.co/datasets/Pointcept/scannetpp-compressed)], please agree the official license before download it.
 - Link processed dataset to codebase:
   ```bash
   # PROCESSED_SCANNETPP_DIR: the directory of the processed ScanNet dataset.
@@ -973,6 +972,21 @@ sh scripts/train.sh -g 8 -d scannet -c pretrain-msc-v1m1-1-spunet-pointcontrast 
 sh scripts/train.sh -g 8 -d scannet -c pretrain-msc-v1m2-0-spunet-csc -n pretrain-msc-v1m2-0-spunet-csc
 ```
 3. Fine-tuning refer [MSC](#masked-scene-contrast-msc).
+
+## Wandb Logging
+1. Run `wandb login`
+2. Add the preferred wandb configuration to the experiment config file. The following table provides the list of possible wandb config params.
+   This table provides details on the configurable parameters used in the project.
+
+| Name               | Type    | Description                                      | Example Value  |
+|--------------------|--------|--------------------------------------------------|---------------|
+| `enable_wandb`     | boolean | Flag to enable or disable W&B logging. | `True` |
+| `wandb_project_name` | string  | The name of the Weights & Biases (W&B) project where logs will be stored. | `"pointcept"` |
+| `wandb_tags`       | list    | Tags associated with the W&B run for categorization and filtering. | `["oa-cnn"]` |
+| `use_step_logging` | boolean | If `True`, enables step-based logging instead of epoch-based logging. | `True` |
+| `log_every`        | integer | Defines how frequently (in steps) logs should be recorded. | `500` |
+
+For more info refer to [W&B](https://docs.wandb.ai/ref/)
 
 ## Acknowledgement
 _Pointcept_ is designed by [Xiaoyang](https://xywu.me/), named by [Yixing](https://github.com/yxlao) and the logo is created by [Yuechen](https://julianjuaner.github.io/). It is derived from [Hengshuang](https://hszhao.github.io/)'s [Semseg](https://github.com/hszhao/semseg) and inspirited by several repos, e.g., [MinkowskiEngine](https://github.com/NVIDIA/MinkowskiEngine), [pointnet2](https://github.com/charlesq34/pointnet2), [mmcv](https://github.com/open-mmlab/mmcv/tree/master/mmcv), and [Detectron2](https://github.com/facebookresearch/detectron2).

--- a/configs/scannetpp/semseg-cac-v1m1-0-base.py
+++ b/configs/scannetpp/semseg-cac-v1m1-0-base.py
@@ -308,3 +308,14 @@ data = dict(
         ),
     ),
 )
+
+# hook
+hooks = [
+    dict(type="CheckpointLoader"),
+    dict(type="IterationTimer", warmup_iter=2),
+    dict(type="InformationWriter"),
+    dict(type="SemSegEvaluator", write_cls_iou=False),
+    dict(type="CheckpointSaver", save_freq=None),
+    dict(type="PreciseEvaluator", test_last=False),
+    dict(type="SemSegEvaluatorTrain", write_cls_iou=False),
+]

--- a/configs/scannetpp/semseg-cac-v1m1-0-base.py
+++ b/configs/scannetpp/semseg-cac-v1m1-0-base.py
@@ -9,6 +9,12 @@ num_worker = 24
 mix_prob = 0.8
 empty_cache = False
 enable_amp = True
+# logging settings
+wandb_project_name = "pointcept"
+wandb_tags = ["cac"]
+enable_wandb = True
+use_step_logging = True
+log_every = 500
 
 # model settings
 model = dict(

--- a/configs/scannetpp/semseg-oacnn-v1m1-0-base.py
+++ b/configs/scannetpp/semseg-oacnn-v1m1-0-base.py
@@ -9,6 +9,12 @@ num_worker = 24
 mix_prob = 0.8
 empty_cache = False
 enable_amp = True
+# logging settings
+wandb_project_name = "pointcept"
+wandb_tags = ["oacnn"]
+enable_wandb = True
+use_step_logging = True
+log_every = 500
 
 
 model = dict(

--- a/configs/scannetpp/semseg-oacnn-v1m1-0-base.py
+++ b/configs/scannetpp/semseg-oacnn-v1m1-0-base.py
@@ -50,7 +50,6 @@ scheduler = dict(
 dataset_type = "ScanNetPPDataset"
 data_root = "data/scannetpp"
 
-
 data = dict(
     num_classes=100,
     ignore_index=-1,
@@ -279,3 +278,14 @@ data = dict(
         ),
     ),
 )
+
+# hook
+hooks = [
+    dict(type="CheckpointLoader"),
+    dict(type="IterationTimer", warmup_iter=2),
+    dict(type="InformationWriter"),
+    dict(type="SemSegEvaluator", write_cls_iou=False),
+    dict(type="CheckpointSaver", save_freq=None),
+    dict(type="PreciseEvaluator", test_last=False),
+    dict(type="SemSegEvaluatorTrain", write_cls_iou=False),
+]

--- a/configs/scannetpp/semseg-octformer-v1m1-0-base.py
+++ b/configs/scannetpp/semseg-octformer-v1m1-0-base.py
@@ -55,7 +55,6 @@ param_dicts = [dict(keyword="blocks", lr=0.00015)]
 dataset_type = "ScanNetPPDataset"
 data_root = "data/scannetpp"
 
-
 data = dict(
     num_classes=100,
     ignore_index=-1,
@@ -284,3 +283,14 @@ data = dict(
         ),
     ),
 )
+
+# hook
+hooks = [
+    dict(type="CheckpointLoader"),
+    dict(type="IterationTimer", warmup_iter=2),
+    dict(type="InformationWriter"),
+    dict(type="SemSegEvaluator", write_cls_iou=False),
+    dict(type="CheckpointSaver", save_freq=None),
+    dict(type="PreciseEvaluator", test_last=False),
+    dict(type="SemSegEvaluatorTrain", write_cls_iou=False),
+]

--- a/configs/scannetpp/semseg-octformer-v1m1-0-base.py
+++ b/configs/scannetpp/semseg-octformer-v1m1-0-base.py
@@ -9,6 +9,12 @@ num_worker = 24
 mix_prob = 0.8
 empty_cache = False
 enable_amp = True
+# logging settings
+wandb_project_name = "pointcept"
+wandb_tags = ["octformer"]
+enable_wandb = True
+use_step_logging = True
+log_every = 500
 
 
 model = dict(

--- a/configs/scannetpp/semseg-pt-v2m2-0-base.py
+++ b/configs/scannetpp/semseg-pt-v2m2-0-base.py
@@ -9,6 +9,12 @@ num_worker = 24
 mix_prob = 0.8
 empty_cache = False
 enable_amp = True
+# logging settings
+enable_wandb = True
+wandb_project_name = "pointcept"
+wandb_tags = ["PTv2"]
+use_step_logging = True
+log_every = 500
 
 # model settings
 model = dict(

--- a/configs/scannetpp/semseg-pt-v2m2-1-lovasz.py
+++ b/configs/scannetpp/semseg-pt-v2m2-1-lovasz.py
@@ -9,6 +9,13 @@ num_worker = 24
 mix_prob = 0.8
 empty_cache = False
 enable_amp = True
+# logging settings
+enable_wandb = True
+wandb_project_name = "pointcept"
+wandb_tags = ["PTv2"]
+use_step_logging = True
+log_every = 500
+
 
 # model settings
 model = dict(
@@ -287,3 +294,14 @@ data = dict(
         ),
     ),
 )
+
+# hook
+hooks = [
+    dict(type="CheckpointLoader"),
+    dict(type="IterationTimer", warmup_iter=2),
+    dict(type="InformationWriter"),
+    dict(type="SemSegEvaluator", write_cls_iou=False),
+    dict(type="CheckpointSaver", save_freq=None),
+    dict(type="PreciseEvaluator", test_last=False),
+    dict(type="SemSegEvaluatorTrain", write_cls_iou=False),
+]

--- a/configs/scannetpp/semseg-pt-v3m1-0-base.py
+++ b/configs/scannetpp/semseg-pt-v3m1-0-base.py
@@ -9,6 +9,12 @@ num_worker = 24
 mix_prob = 0.8
 empty_cache = False
 enable_amp = True
+# logging settings
+enable_wandb = True
+wandb_project_name = "pointcept"
+wandb_tags = ["PTv3"]
+use_step_logging = True
+log_every = 500
 
 # model settings
 model = dict(

--- a/configs/scannetpp/semseg-pt-v3m1-0-base.py
+++ b/configs/scannetpp/semseg-pt-v3m1-0-base.py
@@ -304,3 +304,14 @@ data = dict(
         ),
     ),
 )
+
+# hook
+hooks = [
+    dict(type="CheckpointLoader"),
+    dict(type="IterationTimer", warmup_iter=2),
+    dict(type="InformationWriter"),
+    dict(type="SemSegEvaluator", write_cls_iou=False),
+    dict(type="CheckpointSaver", save_freq=None),
+    dict(type="PreciseEvaluator", test_last=False),
+    dict(type="SemSegEvaluatorTrain", write_cls_iou=False),
+]

--- a/configs/scannetpp/semseg-spunet-v1m1-0-base.py
+++ b/configs/scannetpp/semseg-spunet-v1m1-0-base.py
@@ -9,6 +9,12 @@ num_worker = 24
 mix_prob = 0.8
 empty_cache = False
 enable_amp = True
+# logging settings
+wandb_project_name = "pointcept"
+wandb_tags = ["spunet"]
+enable_wandb = True
+use_step_logging = True
+log_every = 500
 
 # model settings
 model = dict(

--- a/configs/scannetpp/semseg-spunet-v1m1-1-lovasz.py
+++ b/configs/scannetpp/semseg-spunet-v1m1-1-lovasz.py
@@ -270,3 +270,14 @@ data = dict(
         ),
     ),
 )
+
+# hook
+hooks = [
+    dict(type="CheckpointLoader"),
+    dict(type="IterationTimer", warmup_iter=2),
+    dict(type="InformationWriter"),
+    dict(type="SemSegEvaluator", write_cls_iou=False),
+    dict(type="CheckpointSaver", save_freq=None),
+    dict(type="PreciseEvaluator", test_last=False),
+    dict(type="SemSegEvaluatorTrain", write_cls_iou=False),
+]

--- a/pointcept/engines/hooks/evaluator.py
+++ b/pointcept/engines/hooks/evaluator.py
@@ -112,7 +112,9 @@ class SemSegEvaluator(HookBase):
             self.eval()
 
     def eval(self):
-        self.trainer.logger.info(">>>>>>>>>>>>>>>> Start Evaluation >>>>>>>>>>>>>>>>")
+        self.trainer.logger.info(
+            ">>>>>>>>>>>>>>>> Start Evaluation Val >>>>>>>>>>>>>>>>"
+        )
         self.trainer.model.eval()
         for i, input_dict in enumerate(self.trainer.val_loader):
             for key in input_dict.keys():
@@ -194,12 +196,22 @@ class SemSegEvaluator(HookBase):
             self.trainer.writer.add_scalar("val/mIoU", m_iou, current_epoch)
             self.trainer.writer.add_scalar("val/mAcc", m_acc, current_epoch)
             self.trainer.writer.add_scalar("val/allAcc", all_acc, current_epoch)
+            self.trainer.wandb.log(
+                {"val/loss": loss_avg, "val/mIoU": m_iou, "val/mAcc": m_acc}
+            )
             if self.write_cls_iou:
                 for i in range(self.trainer.cfg.data.num_classes):
                     self.trainer.writer.add_scalar(
                         f"val/cls_{i}-{self.trainer.cfg.data.names[i]} IoU",
                         iou_class[i],
                         current_epoch,
+                    )
+                    self.trainer.wandb.log(
+                        {
+                            f"val/cls_{i}-{self.trainer.cfg.data.names[i]} IoU": iou_class[
+                                i
+                            ]
+                        }
                     )
         self.trainer.logger.info("<<<<<<<<<<<<<<<<< End Evaluation <<<<<<<<<<<<<<<<<")
         self.trainer.comm_info["current_metric_value"] = m_iou  # save for saver

--- a/pointcept/engines/hooks/misc.py
+++ b/pointcept/engines/hooks/misc.py
@@ -114,12 +114,16 @@ class InformationWriter(HookBase):
         self.trainer.comm_info["iter_info"] = ""  # reset iter info
         if self.trainer.writer is not None:
             self.trainer.writer.add_scalar("params/lr", lr, self.curr_iter)
+            self.trainer.wandb.log({"params/lr": lr})
             for key in self.model_output_keys:
+                val = self.trainer.storage.history(key).val
                 self.trainer.writer.add_scalar(
                     "train_batch/" + key,
-                    self.trainer.storage.history(key).val,
+                    val,
                     self.curr_iter,
                 )
+                self.trainer.wandb.log({f"batch/{key}": val})
+                self.trainer.wandb.add_to_running_metrics(key, val)
 
     def after_epoch(self):
         epoch_info = "Train result: "
@@ -134,6 +138,9 @@ class InformationWriter(HookBase):
                     "train/" + key,
                     self.trainer.storage.history(key).avg,
                     self.trainer.epoch + 1,
+                )
+                self.trainer.wandb.log(
+                    {f"train/{key}": self.trainer.storage.history(key).val}
                 )
 
 

--- a/pointcept/engines/train.py
+++ b/pointcept/engines/train.py
@@ -19,6 +19,7 @@ if sys.version_info >= (3, 10):
 else:
     from collections import Iterator
 from tensorboardX import SummaryWriter
+import copy
 
 from .defaults import create_ddp_model, worker_init_fn
 from .hooks import HookBase, build_hooks
@@ -30,6 +31,7 @@ from pointcept.utils.optimizer import build_optimizer
 from pointcept.utils.scheduler import build_scheduler
 from pointcept.utils.events import EventStorage, ExceptionWriter
 from pointcept.utils.registry import Registry
+from pointcept.engines.utils.wandb import Wandb
 
 
 TRAINERS = Registry("trainers")
@@ -123,6 +125,7 @@ class TrainerBase:
 class Trainer(TrainerBase):
     def __init__(self, cfg):
         super(Trainer, self).__init__()
+        wandb_cfg = copy.deepcopy(cfg)
         self.epoch = 0
         self.start_epoch = 0
         self.max_epoch = cfg.eval_epoch
@@ -149,6 +152,29 @@ class Trainer(TrainerBase):
         self.scaler = self.build_scaler()
         self.logger.info("=> Building hooks ...")
         self.register_hooks(self.cfg.hooks)
+        self.init_wandb(cfg, wandb_cfg)
+        self.global_step = 0
+
+    def init_wandb(self, cfg, wandb_cfg):
+        wandb_project_name = cfg.get("wandb_project_name", "pointcept")
+        wandb_tags = cfg.get("wandb_tags", [])
+        self.enable_wandb = cfg.get("enable_wandb", False)
+        self.use_step_logging = cfg.get("use_step_logging", False)
+        self.log_every = cfg.get(
+            "log_every", 500
+        )  # Default log every 500 steps if enabled
+
+        self.wandb = Wandb(
+            self.enable_wandb,
+            wandb_project_name,
+            self.logger,
+            tags=wandb_tags,
+            cfg=wandb_cfg,
+            use_step_logging=self.use_step_logging,
+            print_every=self.log_every,
+        )
+
+        self.wandb.init()
 
     def train(self):
         with EventStorage() as self.storage, ExceptionWriter():
@@ -159,6 +185,7 @@ class Trainer(TrainerBase):
                 # => before epoch
                 if comm.get_world_size() > 1:
                     self.train_loader.sampler.set_epoch(self.epoch)
+                self.wandb.set_epoch(self.epoch)
                 self.model.train()
                 self.data_iterator = enumerate(self.train_loader)
                 self.before_epoch()
@@ -173,6 +200,8 @@ class Trainer(TrainerBase):
                     self.run_step()
                     # => after_step
                     self.after_step()
+                    self.global_step += 1
+                    self.wandb.set_global_step(self.global_step)
                 # => after epoch
                 self.after_epoch()
             # => after train
@@ -222,6 +251,7 @@ class Trainer(TrainerBase):
         if self.cfg.empty_cache:
             torch.cuda.empty_cache()
         self.comm_info["model_output_dict"] = output_dict
+        self.comm_info["model_input_dict"] = input_dict
 
     def after_epoch(self):
         for h in self.hooks:

--- a/pointcept/engines/utils/wandb.py
+++ b/pointcept/engines/utils/wandb.py
@@ -1,0 +1,61 @@
+import wandb
+import numpy as np
+
+
+class Wandb:
+    def __init__(
+        self,
+        enabled,
+        project_name,
+        logger,
+        tags=[],
+        cfg={},
+        use_step_logging=False,
+        print_every=10,
+    ):
+        self.global_step = 0
+        self.epoch = 0
+        self.enabled = enabled
+        self.use_step_logging = use_step_logging
+        self.logger = logger
+        self.project_name = project_name
+        self.tags = tags
+        self.cfg = cfg
+        self.running_metrics = {}
+        self.print_every = print_every
+
+    def set_epoch(self, epoch):
+        self.epoch = epoch + 1
+
+    def set_global_step(self, global_step):
+        self.global_step = global_step + 1
+        if self.global_step % self.print_every == 0:
+            self.log_running_metrics()
+
+    def init(self):
+        if not self.enabled:
+            self.logger.info("Wandb not enabled")
+            return None
+        wandb.init(
+            project=self.project_name,
+            tags=self.tags,
+            config=self.cfg,
+            name=self.cfg.run_name,
+        )
+
+    def log(self, data_dict):
+        if not self.enabled:
+            return
+        step = self.global_step if self.use_step_logging else self.epoch
+        wandb.log(data_dict, step=step)
+
+    def add_to_running_metrics(self, key, val):
+        current_values = self.running_metrics.get(key, np.array([]))
+        next_values = np.append(current_values, val)
+        self.running_metrics[key] = next_values
+
+    def log_running_metrics(self):
+        for key, values in self.running_metrics.items():
+            mean_value = np.mean(values)
+            self.log({f"freq/{key}": mean_value})
+        self.running_metrics = {}

--- a/pointcept/models/context_aware_classifier/context_aware_classifier_v1m1_base.py
+++ b/pointcept/models/context_aware_classifier/context_aware_classifier_v1m1_base.py
@@ -246,6 +246,7 @@ class CACSegmentor(nn.Module):
                 pre_loss=pre_loss,
                 pre_self_loss=pre_self_loss,
                 kl_loss=kl_loss,
+                seg_logits=seg_logits,
             )
 
         elif "segment" in data_dict.keys():

--- a/pointcept/models/default.py
+++ b/pointcept/models/default.py
@@ -25,7 +25,7 @@ class DefaultSegmentor(nn.Module):
         # train
         if self.training:
             loss = self.criteria(seg_logits, input_dict["segment"])
-            return dict(loss=loss)
+            return dict(loss=loss, seg_logits=seg_logits)
         # eval
         elif "segment" in input_dict.keys():
             loss = self.criteria(seg_logits, input_dict["segment"])
@@ -82,6 +82,7 @@ class DefaultSegmentorV2(nn.Module):
         if self.training:
             loss = self.criteria(seg_logits, input_dict["segment"])
             return_dict["loss"] = loss
+            return_dict["seg_logits"] = seg_logits
         # eval
         elif "segment" in input_dict.keys():
             loss = self.criteria(seg_logits, input_dict["segment"])

--- a/pointcept/utils/events.py
+++ b/pointcept/utils/events.py
@@ -398,6 +398,14 @@ class EventStorage:
             raise KeyError("No history metric available for {}!".format(name))
         return ret
 
+    def includes(self, name):
+        """
+        Returns:
+            bool: if the history includes the metric
+        """
+        ret = self._history.get(name, None)
+        return ret is not None
+
     def histories(self):
         """
         Returns:


### PR DESCRIPTION
## In this PR,
The main idea is to log the semantic segmentation (IOU, Accuracy) metrics during training so that they can be compared with the validation metrics in addition to the loss.

### Changes
* Added a `SemSegEvaluatorTrain` hook that writes the training metrics to the tensorboard and wandb.
* Added the hook in the default configuration for `scannetpp` methods.
* Semantic segmenation models now also return the `seg_logits` during training for evaluation.
---
### Demo
![image](https://github.com/user-attachments/assets/21468552-bb25-4647-af0d-797f19df8ad4)

The full logs can be found [here](https://api.wandb.ai/links/streakfull-technical-university-of-munich/ed0erarb).
---
*Note this PR depends on another open PR, which can be found [here](https://github.com/Pointcept/Pointcept/pull/413)*.