### PR TITLE
Fix error `ImportError:cannot import nameized module 'pointcept.engines.test'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ Pointcept by default enables both `tensorboard` and `wandb`. There are some usag
 During training, model evaluation is performed on point clouds after grid sampling (voxelization), providing an initial assessment of model performance. However, to obtain precise evaluation results, testing is **essential**. The testing process involves subsampling a dense point cloud into a sequence of voxelized point clouds, ensuring comprehensive coverage of all points. These sub-results are then predicted and collected to form a complete prediction of the entire point cloud. This approach yields  higher evaluation results compared to simply mapping/interpolating the prediction. In addition, our testing code supports TTA (test time augmentation) testing, which further enhances the stability of evaluation performance.
 
 ```bash
+# Hints: add `ulimit -n 1048576` to the terminal for ScanNet++
 # By script (Based on experiment folder created by training script)
 sh scripts/test.sh -p ${INTERPRETER_PATH} -g ${NUM_GPU} -d ${DATASET_NAME} -n ${EXP_NAME} -w ${CHECKPOINT_NAME}
 # Direct

--- a/pointcept/engines/test.py
+++ b/pointcept/engines/test.py
@@ -26,6 +26,7 @@ from pointcept.utils.misc import (
     intersection_and_union_gpu,
     make_dirs,
 )
+from pointcept.engines.hooks import HOOKS, HookBase
 
 
 TESTERS = Registry("testers")
@@ -884,3 +885,30 @@ class PartSegTester(TesterBase):
     @staticmethod
     def collate_fn(batch):
         return collate_fn(batch)
+
+
+@HOOKS.register_module()
+class PreciseEvaluator(HookBase):
+    def __init__(self, test_last=False):
+        self.test_last = test_last
+
+    def after_train(self):
+        self.trainer.logger.info(
+            ">>>>>>>>>>>>>>>> Start Precise Evaluation >>>>>>>>>>>>>>>>"
+        )
+        torch.cuda.empty_cache()
+        cfg = self.trainer.cfg
+        tester = TESTERS.build(
+            dict(type=cfg.test.type, cfg=cfg, model=self.trainer.model)
+        )
+        if self.test_last:
+            self.trainer.logger.info("=> Testing on model_last ...")
+        else:
+            self.trainer.logger.info("=> Testing on model_best ...")
+            best_path = os.path.join(
+                self.trainer.cfg.save_path, "model", "model_best.pth"
+            )
+            checkpoint = torch.load(best_path, weights_only=False)
+            state_dict = checkpoint["state_dict"]
+            tester.model.load_state_dict(state_dict, strict=True)
+        tester.test()


### PR DESCRIPTION
I find an error when running `CUDA_VISIBLE_DEVICES=0,1,2,3 sh scripts/test.sh -g 4 -d scannetpp -n confg_name -w model_best`
![9102669f0e897c2904fc96967713dc8](https://github.com/user-attachments/assets/0816d508-2432-4e8f-8f5a-bb4d3a1f9539)
It is because of a circular import of TESTER.
I just simply move `PreciseEvaluator` to `pointcept/engines/test.py`
