### PR TITLE
Add gradient accumulation option

### DIFF
--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -7,6 +7,7 @@ seed = None  # train process will init a random seed and record
 save_path = "exp/default"
 num_worker = 16  # total worker in all gpu
 batch_size = 16  # total batch size in all gpu
+gradient_accumulation_steps = 1 # total steps to accumulate gradients for
 batch_size_val = None  # auto adapt to bs 1 for each gpu
 batch_size_test = None  # auto adapt to bs 1 for each gpu
 epoch = 100  # total epoch, data loop = epoch // eval_epoch

--- a/pointcept/engines/train.py
+++ b/pointcept/engines/train.py
@@ -151,6 +151,7 @@ class Trainer(TrainerBase):
         self.scaler = self.build_scaler()
         self.logger.info("=> Building hooks ...")
         self.register_hooks(self.cfg.hooks)
+        self._gradient_accumulation_counter = 0
 
     def train(self):
         with EventStorage() as self.storage, ExceptionWriter():
@@ -192,35 +193,51 @@ class Trainer(TrainerBase):
             if isinstance(input_dict[key], torch.Tensor):
                 input_dict[key] = input_dict[key].cuda(non_blocking=True)
 
+        # Only clear gradients on first accumulation step
+        if self._gradient_accumulation_counter == 0:
+            self.optimizer.zero_grad()
+
+        # Forward pass
         with auto_cast(
             enabled=self.cfg.enable_amp, dtype=AMP_DTYPE[self.cfg.amp_dtype]
         ):
             output_dict = self.model(input_dict)
-            loss = output_dict["loss"]
-        self.optimizer.zero_grad()
+            loss = output_dict["loss"] / self.cfg.gradient_accumulation_steps  # scale loss
+
+        # Backward pass
         if self.cfg.enable_amp:
             self.scaler.scale(loss).backward()
-            self.scaler.unscale_(self.optimizer)
-            if self.cfg.clip_grad is not None:
-                torch.nn.utils.clip_grad_norm_(
-                    self.model.parameters(), self.cfg.clip_grad
-                )
-            self.scaler.step(self.optimizer)
-
-            # When enable amp, optimizer.step call are skipped if the loss scaling factor is too large.
-            # Fix torch warning scheduler step before optimizer step.
-            scaler = self.scaler.get_scale()
-            self.scaler.update()
-            if scaler <= self.scaler.get_scale():
-                self.scheduler.step()
         else:
             loss.backward()
-            if self.cfg.clip_grad is not None:
-                torch.nn.utils.clip_grad_norm_(
-                    self.model.parameters(), self.cfg.clip_grad
-                )
-            self.optimizer.step()
-            self.scheduler.step()
+        self._gradient_accumulation_counter += 1
+
+        # Perform optimizer step only when enough gradients have accumulated
+        if self._gradient_accumulation_counter >= self.cfg.gradient_accumulation_steps:
+            if self.cfg.enable_amp:
+                self.scaler.unscale_(self.optimizer)
+                if self.cfg.clip_grad is not None:
+                    torch.nn.utils.clip_grad_norm_(
+                        self.model.parameters(), self.cfg.clip_grad
+                    )
+                self.scaler.step(self.optimizer)
+
+                # When enable amp, optimizer.step call are skipped if the loss scaling factor is too large.
+                # Fix torch warning scheduler step before optimizer step.
+                scale = self.scaler.get_scale()
+                self.scaler.update()
+                if scale <= self.scaler.get_scale():
+                    self.scheduler.step()
+            else:
+                if self.cfg.clip_grad is not None:
+                    torch.nn.utils.clip_grad_norm_(
+                        self.model.parameters(), self.cfg.clip_grad
+                    )
+                self.optimizer.step()
+                self.scheduler.step()
+
+            # Reset grad accumulation counter
+            self._gradient_accumulation_counter = 0
+
         if self.cfg.empty_cache:
             torch.cuda.empty_cache()
         self.comm_info["model_output_dict"] = output_dict


### PR DESCRIPTION
We encountered memory limitations when pretraining the Sonata model, which forced us to significantly reduce the batch size. To address this, we added support for gradient accumulation, enabling us to train with default hyperparameters on limited GPU memory.

The feature is controlled by the ```gradient_accumulation_steps``` config parameter. When set to ```1``` (the default, as added in the base config), the behavior is identical to before, ensuring backward compatibility.