### PR TITLE
Fix silent overwriting of data loop config option

### DIFF
--- a/pointcept/engines/defaults.py
+++ b/pointcept/engines/defaults.py
@@ -120,7 +120,8 @@ def default_config_parser(file_path, options):
     if cfg.seed is None:
         cfg.seed = get_random_seed()
 
-    cfg.data.train.loop = cfg.epoch // cfg.eval_epoch
+    if not hasattr(cfg.data.train, "loop"):
+        cfg.data.train.loop = cfg.epoch // cfg.eval_epoch
 
     os.makedirs(os.path.join(cfg.save_path, "model"), exist_ok=True)
     if not cfg.resume:


### PR DESCRIPTION
Currently, no matter what value is given for `loop` in the data config, it is silently overwritten after the config is parsed.

This commit fixes the issue, while leaving the default behavior of unspecified loop count unchanged.