### PR TITLE
[Bug-Fix] Fix divide-by-zero error in color normalization when color data is all zeros

### DIFF
--- a/pointcept/datasets/transform.py
+++ b/pointcept/datasets/transform.py
@@ -394,7 +394,15 @@ class ChromaticAutoContrast(object):
         if "color" in data_dict.keys() and np.random.rand() < self.p:
             lo = np.min(data_dict["color"], 0, keepdims=True)
             hi = np.max(data_dict["color"], 0, keepdims=True)
-            scale = 255 / (hi - lo)
+            diff = hi - lo
+            if not np.any(diff > 0):
+                return data_dict
+            scale = np.divide(
+                255,
+                diff,
+                out=np.ones_like(diff, dtype=data_dict["color"].dtype),
+                where=diff > 0,
+            )
             contrast_feat = (data_dict["color"][:, :3] - lo) * scale
             blend_factor = (
                 np.random.rand() if self.blend_factor is None else self.blend_factor


### PR DESCRIPTION
This pull request fixes a divide-by-zero issue that occurs during color normalization when the input color data has no variation (e.g., all zeros).
Previously, this caused NaN values to appear during training when using a dataset without color information. This is due to diff = hi - lo evaluating to zero and the subsequent division by zero in the normalization step.