### PR TITLE
Allow for nested subdirectories in DefaultDataset

### DIFF
--- a/pointcept/datasets/defaults.py
+++ b/pointcept/datasets/defaults.py
@@ -6,8 +6,9 @@ Please cite our work if the code is helpful to you.
 """
 
 import os
-import glob
 import json
+from pathlib import Path
+
 import numpy as np
 import torch
 from copy import deepcopy
@@ -28,6 +29,8 @@ INTERPOLATION_MODE = {
     "bicubic": InterpolationMode.BICUBIC,
     "nearest": InterpolationMode.NEAREST,
 }
+
+COORD_ASSET_NAME = "coord.npy"
 
 
 @DATASETS.register_module()
@@ -54,7 +57,7 @@ class DefaultDataset(Dataset):
         loop=1,
     ):
         super(DefaultDataset, self).__init__()
-        self.data_root = data_root
+        self.data_root = Path(data_root)
         self.split = split
         self.transform = Compose(transform)
         self.cache = cache
@@ -75,9 +78,7 @@ class DefaultDataset(Dataset):
         self.data_list = self.get_data_list()
         logger = get_root_logger()
         logger.info(
-            "Totally {} x {} samples in {} {} set.".format(
-                len(self.data_list), self.loop, os.path.basename(self.data_root), split
-            )
+            f"Total {len(self.data_list)} x {self.loop} samples in {self.data_root} {split} set."
         )
 
     def get_data_list(self):
@@ -90,13 +91,12 @@ class DefaultDataset(Dataset):
 
         data_list = []
         for split in split_list:
-            if os.path.isfile(os.path.join(self.data_root, split)):
-                with open(os.path.join(self.data_root, split)) as f:
-                    data_list += [
-                        os.path.join(self.data_root, data) for data in json.load(f)
-                    ]
+            split_path = self.data_root / split
+            if split_path.suffix == ".json" and split_path.is_file():
+                with open(split_path) as f:
+                    data_list += [self.data_root / data for data in json.load(f)]
             else:
-                data_list += glob.glob(os.path.join(self.data_root, split, "*"))
+                data_list += [c.parent for c in split_path.rglob(COORD_ASSET_NAME)]
         return data_list
 
     def get_data(self, idx):
@@ -108,13 +108,11 @@ class DefaultDataset(Dataset):
             return shared_dict(cache_name)
 
         data_dict = {}
-        assets = os.listdir(data_path)
+        assets = data_path.glob("*.npy")
         for asset in assets:
-            if not asset.endswith(".npy"):
+            if asset.stem not in self.VALID_ASSETS:
                 continue
-            if asset[:-4] not in self.VALID_ASSETS:
-                continue
-            data_dict[asset[:-4]] = np.load(os.path.join(data_path, asset))
+            data_dict[asset.stem] = np.load(asset)
         data_dict["name"] = name
         data_dict["split"] = split
 
@@ -143,12 +141,11 @@ class DefaultDataset(Dataset):
         return data_dict
 
     def get_data_name(self, idx):
-        return os.path.basename(self.data_list[idx % len(self.data_list)])
+        return self.data_list[idx % len(self.data_list)].name
 
     def get_split_name(self, idx):
-        return os.path.basename(
-            os.path.dirname(self.data_list[idx % len(self.data_list)])
-        )
+        data_path = self.data_list[idx % len(self.data_list)]
+        return data_path.relative_to(self.data_root).parts[0]
 
     def prepare_train_data(self, idx):
         # load data


### PR DESCRIPTION
While retaining the original behavior with regards to data splits stored in `.json` files, I add support for nested subdirectory structures.

This works under the assumption that every point cloud MUST contain at least its `coord` asset (otherwise it's not a point cloud). That means that every individual point cloud's assets (normals, color, etc.) in a train/val/etc. split's directory can be located by finding the parent directory of every `coord` asset.

Given the following `train` split directory structure
```
train
|_pc1
|   |_coord.npy
|   |_color.npy
|_pc2
|   |_coord.npy
|   |_color.npy
|_extra
    |_pc3
        |_coord.npy
        |_color.npy
```

When the data split is specified as a subdirectory, and not as a json file

Old behavior: `pc1` and `pc2` are included in the training set, `pc3` inside `extra` is skipped
New behavior: `pc1`, `pc2` and `pc3` are included in the training set

This is a very convenient change for constantly changing datasets, since repeatedly updating a json file is bothersome and error-prone. I've used this modification for months now without issues, so I'd like to contribute it to the community.