### PR TITLE
Fix incompatible flashattn during docker build

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -70,7 +70,7 @@ RUN pip install git+https://github.com/openai/CLIP.git
 RUN TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0" pip install -U git+https://github.com/microsoft/Swin3D.git -v --no-build-isolation
 
 # Build FlashAttention2
-RUN TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0" pip install git+https://github.com/Dao-AILab/flash-attention.git --no-build-isolation
+RUN TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0" pip install git+https://github.com/Dao-AILab/flash-attention.git@v2.8.3 --no-build-isolation
 
 # Build pointops
 RUN git clone https://github.com/Pointcept/Pointcept.git


### PR DESCRIPTION
The flash attention repo got major updates, which caused incompatibility with the docker build's environment. Compiling the latest flash attention fails with error:
```
nvcc fatal   : Unsupported gpu architecture 'compute_120'
```

Which seems to indicate an outdated pytorch/cuda version https://github.com/Dao-AILab/flash-attention/issues/1916
Pinning the last non-beta release of flash attention makes the build stable and future-proof.

With some modifications, I also managed to build pytorch 2.11 and cuda 12.8, which successfully compiles the latest flash attention, but then Swin3D cannot be compiled, and I did not bother troubleshooting it since all I use is PTv3. I could give it another look if you think it'd be valuable.