### PR TITLE
fix collect offset generation

### DIFF
--- a/pointcept/datasets/transform.py
+++ b/pointcept/datasets/transform.py
@@ -64,9 +64,6 @@ class Collect(object):
 
     def __call__(self, data_dict):
         data = dict()
-        data_dict["offset"] = torch.cumsum(
-            torch.tensor([data.shape[0] for data in data_dict["coord"]]), dim=0
-        )
         if isinstance(self.keys, str):
             self.keys = [self.keys]
         for key in self.keys:


### PR DESCRIPTION
## What changed

This PR removes an incorrect intermediate `offset` assignment from `Collect.__call__` in `pointcept/datasets/transform.py`.

## Why

`Collect` already generates returned offsets through `offset_keys_dict`:

```python
data[key] = torch.tensor([data_dict[value].shape[0]])
```

For the default configuration, this means `offset` is generated from `coord.shape[0]`, which is the number of points in the current sample. The dataloader collate step later converts per-sample point counts into cumulative batch offsets.

The removed code tried to precompute `data_dict["offset"]` with:

```python
torch.cumsum(torch.tensor([data.shape[0] for data in data_dict["coord"]]), dim=0)
```

For a normal point cloud coordinate tensor shaped `[N, 3]`, iterating over `data_dict["coord"]` yields each point row with shape `[3]`. Therefore `data.shape[0]` is `3` for every point, producing offsets like `[3, 6, 9, ...]` instead of `[N]` or `[N1, N1 + N2, ...]`.

That intermediate value is also misleading because it mutates the input `data_dict`, while the actual returned `data["offset"]` is generated again afterward by `offset_keys_dict`. Removing it keeps `Collect` focused on returning the correct per-sample point count and avoids leaving an incorrect temporary offset in the source dictionary.

## Impact

- Keeps the existing public `Collect` output behavior intact for standard configs.
- Avoids incorrect offset computation for regular `[N, 3]` coordinate tensors.
- Avoids unnecessary mutation of `data_dict` inside `Collect.__call__`.
- Leaves batch-level cumulative offset construction to the existing dataset `collate_fn` logic.

## Validation

Ran a temporary local Python check confirming that:

```python
Collect(keys=["coord"])(dict(coord=torch.ones(5, 3)))["offset"]
```

returns `[5]`, matching the expected point count for one sample.