### PR TITLE
Fix Point Transformer V3 flash attention dtype selection

### DIFF
--- a/pointcept/models/point_transformer_v3/point_transformer_v3m1_base.py
+++ b/pointcept/models/point_transformer_v3/point_transformer_v3m1_base.py
@@ -87,6 +87,7 @@ class SerializedAttention(PointModule):
             assert flash_attn is not None, "Make sure flash_attn is installed."
             self.patch_size = patch_size
             self.attn_drop = attn_drop
+            self.flash_dtype = None
         else:
             # when disable flash attention, we still don't want to use mask
             # consequently, patch size will auto set to the
@@ -205,8 +206,14 @@ class SerializedAttention(PointModule):
             attn = self.attn_drop(attn).to(qkv.dtype)
             feat = (attn @ v).transpose(1, 2).reshape(-1, C)
         else:
+            if self.flash_dtype is None:
+                self.flash_dtype = (
+                    torch.bfloat16
+                    if torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+                    else torch.float16
+                )
             feat = flash_attn.flash_attn_varlen_qkvpacked_func(
-                qkv.to(torch.bfloat16).reshape(-1, 3, H, C // H),
+                qkv.to(self.flash_dtype).reshape(-1, 3, H, C // H),
                 cu_seqlens,
                 max_seqlen=self.patch_size,
                 dropout_p=self.attn_drop if self.training else 0,

--- a/pointcept/models/point_transformer_v3/point_transformer_v3m2_sonata.py
+++ b/pointcept/models/point_transformer_v3/point_transformer_v3m2_sonata.py
@@ -100,6 +100,7 @@ class SerializedAttention(PointModule):
             assert flash_attn is not None, "Make sure flash_attn is installed."
             self.patch_size = patch_size
             self.attn_drop = attn_drop
+            self.flash_dtype = None
         else:
             # when disable flash attention, we still don't want to use mask
             # consequently, patch size will auto set to the
@@ -218,8 +219,14 @@ class SerializedAttention(PointModule):
             attn = self.attn_drop(attn).to(qkv.dtype)
             feat = (attn @ v).transpose(1, 2).reshape(-1, C)
         else:
+            if self.flash_dtype is None:
+                self.flash_dtype = (
+                    torch.bfloat16
+                    if torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+                    else torch.float16
+                )
             feat = flash_attn.flash_attn_varlen_qkvpacked_func(
-                qkv.to(torch.bfloat16).reshape(-1, 3, H, C // H),
+                qkv.to(self.flash_dtype).reshape(-1, 3, H, C // H),
                 cu_seqlens,
                 max_seqlen=self.patch_size,
                 dropout_p=self.attn_drop if self.training else 0,

--- a/pointcept/models/point_transformer_v3/point_transformer_v3m3_utonia.py
+++ b/pointcept/models/point_transformer_v3/point_transformer_v3m3_utonia.py
@@ -165,6 +165,7 @@ class SerializedAttention(PointModule):
             assert flash_attn is not None, "Make sure flash_attn is installed."
             self.patch_size = patch_size
             self.attn_drop = attn_drop
+            self.flash_dtype = None
         else:
             # when disable flash attention, we still don't want to use mask
             # consequently, patch size will auto set to the
@@ -320,8 +321,15 @@ class SerializedAttention(PointModule):
                 feat = (attn @ v).transpose(1, 2).reshape(-1, C)
             else:
                 qkv_roped = torch.stack([q, k, v], dim=1)
+                if self.flash_dtype is None:
+                    self.flash_dtype = (
+                        torch.bfloat16
+                        if torch.cuda.is_available()
+                        and torch.cuda.is_bf16_supported()
+                        else torch.float16
+                    )
                 feat = flash_attn.flash_attn_varlen_qkvpacked_func(
-                    qkv_roped.to(torch.bfloat16),
+                    qkv_roped.to(self.flash_dtype),
                     cu_seqlens,
                     max_seqlen=self.patch_size,
                     dropout_p=self.attn_drop if self.training else 0,
@@ -350,8 +358,15 @@ class SerializedAttention(PointModule):
                 attn = self.attn_drop(attn).to(qkv.dtype)
                 feat = (attn @ v).transpose(1, 2).reshape(-1, C)
             else:
+                if self.flash_dtype is None:
+                    self.flash_dtype = (
+                        torch.bfloat16
+                        if torch.cuda.is_available()
+                        and torch.cuda.is_bf16_supported()
+                        else torch.float16
+                    )
                 feat = flash_attn.flash_attn_varlen_qkvpacked_func(
-                    qkv.to(torch.bfloat16).reshape(-1, 3, H, C // H),
+                    qkv.to(self.flash_dtype).reshape(-1, 3, H, C // H),
                     cu_seqlens,
                     max_seqlen=self.patch_size,
                     dropout_p=self.attn_drop if self.training else 0,


### PR DESCRIPTION
## What changed

This PR updates the FlashAttention path in the Point Transformer V3 implementations to choose a supported low-precision dtype dynamically instead of always casting QKV tensors to `torch.bfloat16`.

Updated files:

- `pointcept/models/point_transformer_v3/point_transformer_v3m1_base.py`
- `pointcept/models/point_transformer_v3/point_transformer_v3m2_sonata.py`
- `pointcept/models/point_transformer_v3/point_transformer_v3m3_utonia.py`

The FlashAttention path now initializes and reuses `self.flash_dtype`:

```python
if self.flash_dtype is None:
    self.flash_dtype = (
        torch.bfloat16
        if torch.cuda.is_available() and torch.cuda.is_bf16_supported()
        else torch.float16
    )
```

The QKV tensors are then cast with `qkv.to(self.flash_dtype)` before calling `flash_attn.flash_attn_varlen_qkvpacked_func`, and the output is cast back to the original `qkv.dtype` afterward.

## Why

The previous implementation hard-coded `torch.bfloat16` in the FlashAttention path:

```python
qkv.to(torch.bfloat16)
```

That is only safe on CUDA devices with bfloat16 support. On GPUs that support FlashAttention but do not support bfloat16, this can fail or make the FlashAttention path unusable even though `torch.float16` would be supported.

The updated behavior keeps bfloat16 on hardware that supports it, while falling back to float16 on devices without bfloat16 support. This makes the Point Transformer V3 FlashAttention code path more portable across CUDA GPU generations without changing the non-FlashAttention path.

## Implementation details

- Adds `self.flash_dtype = None` when FlashAttention is enabled.
- Lazily resolves the dtype on first FlashAttention use, based on `torch.cuda.is_available()` and `torch.cuda.is_bf16_supported()`.
- Applies the same dtype selection to:
  - the standard QKV FlashAttention path in `point_transformer_v3m1_base.py`
  - the standard QKV FlashAttention path in `point_transformer_v3m2_sonata.py`
  - both the RoPE QKV path and standard QKV path in `point_transformer_v3m3_utonia.py`
- Keeps the output conversion back to `qkv.dtype`, preserving the surrounding module dtype behavior.

## Validation

Ran Python bytecode compilation for the updated files:

```bash
python -m py_compile \
  pointcept/models/point_transformer_v3/point_transformer_v3m1_base.py \
  pointcept/models/point_transformer_v3/point_transformer_v3m2_sonata.py \
  pointcept/models/point_transformer_v3/point_transformer_v3m3_utonia.py
```

The compilation completed successfully.