### PR TITLE
Fix z-order decode return value handling

### DIFF
--- a/pointcept/models/utils/serialization/default.py
+++ b/pointcept/models/utils/serialization/default.py
@@ -46,7 +46,7 @@ def z_order_encode(grid_coord: torch.Tensor, depth: int = 16):
 
 
 def z_order_decode(code: torch.Tensor, depth):
-    x, y, z = z_order_decode_(code, depth=depth)
+    x, y, z, _ = z_order_decode_(code, depth=depth)
     grid_coord = torch.stack([x, y, z], dim=-1)  # (N,  3)
     return grid_coord
 


### PR DESCRIPTION
## Motivation

`pointcept/models/utils/serialization/z_order.py::key2xyz` returns four values:
`x`, `y`, `z`, and `b`.

However, `pointcept/models/utils/serialization/default.py::z_order_decode`
currently unpacks only three values from `z_order_decode_`, which can raise:

```text
ValueError: too many values to unpack (expected 3)

when z_order_decode is called.

Fixes #486.

## Modification
Update z_order_decode to unpack the fourth return value from
z_order_decode_.
Ignore the returned batch index with _, because this helper only returns
decoded grid coordinates.

## BC-breaking

No backward-incompatible change is expected. This only fixes a return-value
unpacking mismatch and preserves the existing z_order_decode return value.

## Tests

Not run locally. This is a one-line fix for a reported unpacking error, and my
local environment does not have the full Pointcept runtime dependencies
installed.