### PR TITLE
[ROCm] Build Pointcept CUDA extensions on AMD GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you find _Pointcept_ useful to your research, please cite our work as encoura
 
 ### Requirements
 - Ubuntu: 18.04 and above.
-- CUDA: 11.3 and above.
+- CUDA: 11.3 and above (NVIDIA GPUs), or ROCm 7.0 and above (AMD GPUs).
 - PyTorch: 1.10.0 and above.
 
 ### Conda Environment
@@ -213,6 +213,9 @@ If you find _Pointcept_ useful to your research, please cite our work as encoura
   TORCH_CUDA_ARCH_LIST="ARCH LIST" python  setup.py install
   # e.g. 7.5: RTX 3000; 8.0: a100 More available in: https://developer.nvidia.com/cuda-gpus
   TORCH_CUDA_ARCH_LIST="7.5 8.0" python  setup.py install
+  # on AMD GPUs (ROCm), select the target arch with PYTORCH_ROCM_ARCH instead
+  # e.g. gfx90a: MI200; gfx1100: RX 7900 More available in: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html
+  PYTORCH_ROCM_ARCH="gfx90a;gfx1100" python setup.py install
   cd ../..
 
   # Open3D (visualization, optional)

--- a/libs/pointgroup_ops/setup.py
+++ b/libs/pointgroup_ops/setup.py
@@ -5,9 +5,10 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 from distutils.sysconfig import get_config_vars
 
 (opt,) = get_config_vars("OPT")
-os.environ["OPT"] = " ".join(
-    flag for flag in opt.split() if flag != "-Wstrict-prototypes"
-)
+if opt:
+    os.environ["OPT"] = " ".join(
+        flag for flag in opt.split() if flag != "-Wstrict-prototypes"
+    )
 
 
 def _argparse(pattern, argv, is_flag=True, is_list=False):

--- a/libs/pointgroup_ops/src/bfs_cluster.cpp
+++ b/libs/pointgroup_ops/src/bfs_cluster.cpp
@@ -83,12 +83,12 @@ ConnectedComponent find_cc(Int idx, int *semantic_label, Int *ball_query_idxs, i
 //input: start_len, int, (N, 2)
 //output: clusters, CCs
 int get_clusters(int *semantic_label, Int *ball_query_idxs, int *start_len, const Int nPoint, int threshold, ConnectedComponents &clusters){
-    int visited[nPoint] = {0};
+    std::vector<int> visited(nPoint, 0);
 
     int sumNPoint = 0;
     for(Int i = 0; i < nPoint; i++){
         if(visited[i] == 0){
-            ConnectedComponent CC = find_cc(i, semantic_label, ball_query_idxs, start_len, visited);
+            ConnectedComponent CC = find_cc(i, semantic_label, ball_query_idxs, start_len, visited.data());
             if((int)CC.pt_idxs.size() >= threshold){
                 clusters.push_back(CC);
                 sumNPoint += (int)CC.pt_idxs.size();

--- a/libs/pointops/setup.py
+++ b/libs/pointops/setup.py
@@ -4,9 +4,10 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 from distutils.sysconfig import get_config_vars
 
 (opt,) = get_config_vars("OPT")
-os.environ["OPT"] = " ".join(
-    flag for flag in opt.split() if flag != "-Wstrict-prototypes"
-)
+if opt:
+    os.environ["OPT"] = " ".join(
+        flag for flag in opt.split() if flag != "-Wstrict-prototypes"
+    )
 
 src = "src"
 sources = [

--- a/libs/pointops2/setup.py
+++ b/libs/pointops2/setup.py
@@ -4,9 +4,10 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 from distutils.sysconfig import get_config_vars
 
 (opt,) = get_config_vars("OPT")
-os.environ["OPT"] = " ".join(
-    flag for flag in opt.split() if flag != "-Wstrict-prototypes"
-)
+if opt:
+    os.environ["OPT"] = " ".join(
+        flag for flag in opt.split() if flag != "-Wstrict-prototypes"
+    )
 
 src = "src"
 sources = [

--- a/libs/pointrope/setup.py
+++ b/libs/pointrope/setup.py
@@ -5,20 +5,27 @@ Author: Yuanwen Yue (yuayue@ethz.ch)
 Please cite our work if the code is helpful to you.
 """
 
+import torch
 from setuptools import setup
 from torch import cuda
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
-# compile for all possible CUDA architectures
-all_cuda_archs = cuda.get_gencode_flags().replace("compute=", "arch=").split()
-# alternatively, you can list cuda archs that you want, eg:
-# check https://developer.nvidia.com/cuda-gpus to find your arch
-# all_cuda_archs = [
-#     '-gencode', 'arch=compute_90,code=sm_90',
-#     # '-gencode', 'arch=compute_75,code=sm_75',
-#     # '-gencode', 'arch=compute_80,code=sm_80',
-#     # '-gencode', 'arch=compute_86,code=sm_86'
-# ]
+if torch.version.hip is not None:
+    # ROCm/HIP: hipcc rejects the nvcc-only flags below and -gencode; the target
+    # arch comes from PYTORCH_ROCM_ARCH (--offload-arch), so no gencode list.
+    nvcc_args = ["-O3", "-ffast-math"]
+else:
+    # compile for all possible CUDA architectures
+    all_cuda_archs = cuda.get_gencode_flags().replace("compute=", "arch=").split()
+    # alternatively, you can list cuda archs that you want, eg:
+    # check https://developer.nvidia.com/cuda-gpus to find your arch
+    # all_cuda_archs = [
+    #     '-gencode', 'arch=compute_90,code=sm_90',
+    #     # '-gencode', 'arch=compute_75,code=sm_75',
+    #     # '-gencode', 'arch=compute_80,code=sm_80',
+    #     # '-gencode', 'arch=compute_86,code=sm_86'
+    # ]
+    nvcc_args = ["-O3", "--ptxas-options=-v", "--use_fast_math"] + all_cuda_archs
 
 setup(
     name="pointrope",
@@ -30,7 +37,7 @@ setup(
                 "kernels.cu",
             ],
             extra_compile_args=dict(
-                nvcc=["-O3", "--ptxas-options=-v", "--use_fast_math"] + all_cuda_archs,
+                nvcc=nvcc_args,
                 cxx=["-O3"],
             ),
         )


### PR DESCRIPTION
Enable the four bundled CUDA extensions (pointops, pointops2, pointgroup_ops, pointrope) to build and run on AMD GPUs via ROCm. PyTorch's CUDAExtension auto-hipifies the .cu sources, so the kernels need no changes; the build scripts only needed portability fixes.

Review order:

- libs/pointrope/setup.py: the build forces nvcc-only flags (a -gencode list from cuda.get_gencode_flags(), --ptxas-options, --use_fast_math) that hipcc rejects. Branch on torch.version.hip: on ROCm the target arch comes from PYTORCH_ROCM_ARCH (--offload-arch), so emit only the portable flags and no gencode list. The CUDA path is unchanged.
- libs/{pointops,pointops2,pointgroup_ops}/setup.py: get_config_vars("OPT") can return None (e.g. with the ROCm PyTorch wheel's Python config), which made the unconditional opt.split() throw. Guard on opt before rewriting it.
- libs/pointgroup_ops/src/bfs_cluster.cpp: replace a stack VLA (a GCC extension that clang rejects when building on Windows) with std::vector. Behavior is unchanged on every compiler.

Documentation: the README Installation section notes ROCm as a supported alternative and shows selecting the GPU arch with PYTORCH_ROCM_ARCH next to the existing TORCH_CUDA_ARCH_LIST example.

## Test Plan

Built all four extensions on an AMD Instinct MI250X (gfx90a):

```
export HIP_VISIBLE_DEVICES=0 PYTORCH_ROCM_ARCH=gfx90a
cd libs/pointops        && python setup.py install
cd ../pointops2         && python setup.py install
cd ../pointgroup_ops    && python setup.py install
cd ../pointrope         && python setup.py install
```

All four built and produced gfx90a device code (verified with `roc-obj-ls <ext>.so | grep gfx90a`). Ran the bundled pointops2 op tests from libs/pointops2/functions/:

```
yes "" | python test_attention_op_step1.py
yes "" | python test_attention_op_step1_v2.py
yes "" | python test_relative_pos_encoding_op_step1.py
yes "" | python test_relative_pos_encoding_op_step1_v2.py
yes "" | python test_relative_pos_encoding_op_step1_v3.py
yes "" | python test_relative_pos_encoding_op_step2_v2.py
```

The v1-vs-v2/v3 reference comparisons agree (max squared error <= 2.3e-10; the `(diff**2 < 1e-8).all()` checks return True), and the forward+backward tests run on the GPU. Also built and ran on gfx1100, gfx1101, and gfx1201.

This change was authored with the assistance of Claude.
