### PR TITLE
Fix point ordering and double tanh in the Concerto Waymo preprocessing

### DIFF
--- a/pointcept/datasets/preprocessing/concerto/waymo/preprocess_waymo.py
+++ b/pointcept/datasets/preprocessing/concerto/waymo/preprocess_waymo.py
@@ -45,13 +45,11 @@ def project_vehicle_to_image(vehicle_pose, calibration, points):
     Returns:
       Array of shape [N, 3], with the latter dimension composed of (u, v, ok).
     """
-    # Transform points from vehicle to world coordinate system (can be
-    # vectorized).
+    # Transform points from vehicle to world coordinate system.
     pose_matrix = np.array(vehicle_pose.transform).reshape(4, 4)
-    world_points = np.zeros_like(points)
-    for i, point in enumerate(points):
-        cx, cy, cz, _ = np.matmul(pose_matrix, [*point, 1])
-        world_points[i] = (cx, cy, cz)
+    world_points = (points @ pose_matrix[:3, :3].T + pose_matrix[:3, 3]).astype(
+        points.dtype
+    )
 
     # Populate camera image metadata. Velocity and latency stats are filled with
     # zeroes.

--- a/pointcept/datasets/preprocessing/concerto/waymo/preprocess_waymo.py
+++ b/pointcept/datasets/preprocessing/concerto/waymo/preprocess_waymo.py
@@ -162,8 +162,9 @@ def create_lidar_and_normals(frame):
     final_points = np.concatenate(points_0 + points_1, axis=0)
     final_normals = np.concatenate(normals_0 + normals_1, axis=0)
 
+    # Raw intensity: handle_process applies the tanh, as the standard Waymo script does.
     velodyne, _ = create_lidar(frame)
-    strength = np.tanh(velodyne.reshape(-1, 4)[:, -1].reshape([-1, 1]))
+    strength = velodyne.reshape(-1, 4)[:, -1].reshape([-1, 1])
     assert len(final_points) == len(strength) == len(final_normals), (
         f"point/strength/normal length mismatch ({len(final_points)}/{len(strength)}/"
         f"{len(final_normals)}) -- the two orderings have diverged again"

--- a/pointcept/datasets/preprocessing/concerto/waymo/preprocess_waymo.py
+++ b/pointcept/datasets/preprocessing/concerto/waymo/preprocess_waymo.py
@@ -93,6 +93,22 @@ def get_normals(cam_center, coords):
 
 
 def create_lidar_and_normals(frame):
+    """Points plus per-point normals, in the SAME point order as create_lidar/create_label.
+
+    Point order matters here. This file builds the same points two ways:
+
+        per return (create_lidar, create_label):  [s0r0, s1r0 ... snr0, s0r1 ... snr1]
+        per sensor (what this used to do):        [s0r0, s0r1, s1r0, s1r1, ...]
+
+    They are permutations of each other, so mixing them lines up two arrays against different
+    points without any length or shape error. `strength` below comes from create_lidar, which is
+    per return, and handle_process pairs this function's coord with create_label's labels, which
+    is also per return. Building per sensor here therefore misaligned both.
+
+    Normals are still estimated per sensor, because they need that sensor's origin to be oriented
+    and estimate_normals should see both returns of a sensor together. They are then placed back
+    into their per return slots.
+    """
     (
         range_images,
         camera_projections,
@@ -100,56 +116,61 @@ def create_lidar_and_normals(frame):
         range_image_top_pose,
     ) = frame_utils.parse_range_image_and_camera_projection(frame)
 
-    all_points_vehicle_frame = []
-    all_normals_vehicle_frame = []
-    all_valid_masks = []
+    # These return every sensor at once, so calling them inside the per sensor loop recomputed the
+    # whole frame once per sensor.
+    points_0, _, valid_masks_0 = convert_range_image_to_point_cloud(
+        frame,
+        range_images,
+        camera_projections,
+        range_image_top_pose,
+        ri_index=0,
+        keep_polar_features=False,
+    )
+    points_1, _, valid_masks_1 = convert_range_image_to_point_cloud(
+        frame,
+        range_images,
+        camera_projections,
+        range_image_top_pose,
+        ri_index=1,
+        keep_polar_features=False,
+    )
 
+    # Same sort convert_range_image_to_point_cloud uses to index the lists it returns.
     calibrations = sorted(frame.context.laser_calibrations, key=lambda c: c.name)
 
-    for c in calibrations:
-        points_0, _, valid_masks_0 = convert_range_image_to_point_cloud(
-            frame,
-            range_images,
-            camera_projections,
-            range_image_top_pose,
-            ri_index=0,
-            keep_polar_features=False,
-        )
-
-        points_1, _, valid_masks_1 = convert_range_image_to_point_cloud(
-            frame,
-            range_images,
-            camera_projections,
-            range_image_top_pose,
-            ri_index=1,
-            keep_polar_features=False,
-        )
-
-        sensor_index = calibrations.index(c)
+    normals_0, normals_1 = [], []
+    for sensor_index, c in enumerate(calibrations):
         sensor_points_0 = points_0[sensor_index]
         sensor_points_1 = points_1[sensor_index]
-
         sensor_points_all = np.concatenate([sensor_points_0, sensor_points_1], axis=0)
 
         if sensor_points_all.shape[0] == 0:
+            # Append empty blocks rather than `continue`: the point lists still carry this
+            # sensor's empty slots, so skipping would desync normals from points.
+            normals_0.append(np.zeros((len(sensor_points_0), 3)))
+            normals_1.append(np.zeros((len(sensor_points_1), 3)))
             continue
 
         extrinsic = np.array(c.extrinsic.transform).reshape(4, 4)
         lidar_center_vehicle_frame = extrinsic[:3, 3]
 
         normals = get_normals(lidar_center_vehicle_frame, sensor_points_all)
+        normals_0.append(normals[: len(sensor_points_0)])
+        normals_1.append(normals[len(sensor_points_0) :])
 
-        all_points_vehicle_frame.append(sensor_points_all)
-        all_normals_vehicle_frame.append(normals)
-        all_valid_masks.append(valid_masks_0[sensor_index])
-        all_valid_masks.append(valid_masks_1[sensor_index])
+    # List concatenation, not array: [all ri0 blocks] + [all ri1 blocks] is create_lidar's order.
+    final_points = np.concatenate(points_0 + points_1, axis=0)
+    final_normals = np.concatenate(normals_0 + normals_1, axis=0)
 
-    final_points = np.concatenate(all_points_vehicle_frame, axis=0)
-    final_normals = np.concatenate(all_normals_vehicle_frame, axis=0)
     velodyne, _ = create_lidar(frame)
     strength = np.tanh(velodyne.reshape(-1, 4)[:, -1].reshape([-1, 1]))
+    assert len(final_points) == len(strength) == len(final_normals), (
+        f"point/strength/normal length mismatch ({len(final_points)}/{len(strength)}/"
+        f"{len(final_normals)}) -- the two orderings have diverged again"
+    )
     point_cloud_with_strength = np.c_[final_points, strength]
-    return point_cloud_with_strength, final_normals, all_valid_masks
+    # Mirrors create_lidar's [ri0, ri1] shape.
+    return point_cloud_with_strength, final_normals, [valid_masks_0, valid_masks_1]
 
 
 def create_lidar(frame):


### PR DESCRIPTION
**File:** `pointcept/datasets/preprocessing/concerto/waymo/preprocess_waymo.py`
**Introduced in:** #543 (merged 2025-11-24). The standard `pointcept/datasets/preprocessing/waymo/preprocess_waymo.py` is not affected.

This fixes three bugs in the Concerto Waymo preprocessing script. All three are silent. There is no
crash and no shape error, and nothing looks wrong in any metric computed from the resulting store,
because the store is consistent with itself. They only show up when you compare it against a store
built by the standard script from the same tfrecords.

## The cause: two point orderings in one file

The script builds the same points in two different orders:

| function | order |
|---|---|
| `create_lidar` (:155), `create_label` (:197) | **per return**: `concat(all ri0) + concat(all ri1)` |
| `create_lidar_and_normals` (:95) | **per sensor**: loops calibrations, `concat(ri0[s], ri1[s])` |

These are permutations of each other. Two places mix them.

**Bug 1, `coord` vs `segment`.** `handle_process` takes coord and normal from the per sensor
function, and the label from the per return one:

```python
point_cloud, normal, valid_masks = create_lidar_and_normals(frame)   # :475  per SENSOR
...
label = create_label(frame)[:, 1].reshape([-1]) - 1                  # :494  per RETURN
np.save(save_path / timestamp / "segment.npy", label)
```

**Bug 2, `coord` vs `strength`,** inside `create_lidar_and_normals`:

```python
final_points = np.concatenate(all_points_vehicle_frame, axis=0)   # :147  per SENSOR
velodyne, _ = create_lidar(frame)                                 # :149  per RETURN
strength = np.tanh(velodyne.reshape(-1, 4)[:, -1].reshape([-1, 1]))
point_cloud_with_strength = np.c_[final_points, strength]         # :151  zipped together
```

`color` (projected from `coord`) and `normal` (computed inside the per sensor loop) are both
correctly lined up. That is part of why this is easy to miss: two of the four per point fields are
fine.

**Bug 3, `strength` gets `tanh` twice.** This one has nothing to do with ordering.
`create_lidar_and_normals` returns `np.tanh(intensity)` in column 3 (:150), and `handle_process`
then applies `np.tanh` to that same column (:512). So the saved `strength.npy` holds
`tanh(tanh(intensity))`. The standard script applies one `tanh`, on the same line, in the same place.

## What it looks like

Same frame, same points, same order in both panels. Only the label assignment differs.

<img width="3260" height="1170" alt="zoom_000_00" src="https://github.com/user-attachments/assets/b672e8ac-2a93-45aa-9749-0bd9ec6109cc" />

On the left are the correct labels, where the area around the ego vehicle is one clean dark region
(the no-label zone). In the middle is the same frame from this script, where that same area is
filled with colored speckle following the lidar scan lines. Those are real class labels sitting on
points that carry no label. On the right, the affected points are shown in red.

Waymo only labels the TOP lidar, so the wrong ordering mostly swaps labelled TOP second-return
points against unlabelled side lidar first-return points. That is why the damage sits in a ring
around the ego vehicle instead of being spread over the scene.

In numbers, of the points an evaluator actually scores, about 0.7 to 0.8 percent carry a label
belonging to a different point, about 7.5 percent are no-label-zone points scored against a
borrowed label, and about 7.5 percent of real labels are dropped. For `strength`,
`max|tanh(reference) - stored|` is exactly `0.000e+00`, and the value range is squashed from
`[0.0003, 1.0000]` to `[0.0003, 0.7616]`.

## Who is affected

Anything that reads `segment.npy` from a store built by this script, so semantic segmentation
training, linear probes, and any semseg eval, is training and scoring against roughly 8 percent
noise. Anything that feeds `strength` gets an intensity channel that is both scrambled and squashed
twice. Pretraining that uses only `coord`, or `coord + color + normal`, is fine.

Because training and eval are wrong in the same way, and the store agrees with itself, this does not
announce itself. It looks like a slightly weaker model, not like a data bug.

## The fix

Build per return in `create_lidar_and_normals`, and return raw intensity so `handle_process` applies
the single `tanh`. Normals still need to be estimated per sensor, since they need that sensor's
origin to be pointed the right way and `estimate_normals` should see both returns of a sensor
together, so estimate them per sensor and then place them into per return slots.

Two smaller things included:

- The old `if sensor_points_all.shape[0] == 0: continue` skipped a sensor's normals while the point
  lists still had its empty slots. That is the same kind of desync waiting to happen. Appending
  empty blocks avoids it.
- `convert_range_image_to_point_cloud` returns all sensors at once, so calling it inside the per
  sensor loop recomputed the whole frame once per sensor. It is now hoisted out.

## Verification

After the fix, a full re-extraction of all 1150 tfrecords produces `coord.npy`, `segment.npy`,
`strength.npy` and `pose.npy` that are **byte identical** to the standard script's output, checked
over 240 frames and about 37.5 million scored points across both splits, with all three defect rates
at exactly `0.0000%`. The store still carries the `color.npy` and `normal.npy` that the Concerto
variant exists to add.

```
[OK] coord.npy      byte-identical in 120/120 (training) and 120/120 (validation)
[OK] segment.npy    byte-identical
[OK] strength.npy   byte-identical
[OK] pose.npy       byte-identical
[OK] conflict 0.0000%   spurious 0.0000%   dropped 0.0000%
     k-NN label agreement: new 0.9785, reference 0.9785
```

`strength` matching byte for byte is what confirms the double `tanh` fix on its own. That field was
off by 0.238 before.

## Also included: `project_vehicle_to_image` was a per point Python loop

Not a correctness bug, but it dominated the runtime:

```python
world_points = np.zeros_like(points)
for i, point in enumerate(points):
    cx, cy, cz, _ = np.matmul(pose_matrix, [*point, 1])
    world_points[i] = (cx, cy, cz)
```

At roughly 175k points times 5 cameras times 30 labelled frames times 1150 tfrecords, that is about
3e10 passes through a 4x4 matmul against a 3 element list. The comment above it already said "can be
vectorized":

```python
world_points = (points @ pose_matrix[:3, :3].T + pose_matrix[:3, 3]).astype(points.dtype)
```

Bit identical on float32 and float64 (`max|old - new| = 0.000e+00`). With this, one tfrecord takes
about 138 seconds for 30 labelled frames, so a full extraction takes hours instead of weeks.

## Note on `correspondence.npy`

`correspondence.npy` stores `point_idx` that indexes into `coord`, one row per point, so it is only
valid against the ordering it was written with. Anyone regenerating a store with this fix needs to
regenerate the `images/` tree too, not just the point data.