### PR TITLE
Allow multi-machine train.sh/test.sh outside Slurm via -u/-k options

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,13 @@ sh scripts/train.sh -p ${INTERPRETER_PATH} -g ${NUM_GPU} -d ${DATASET_NAME} -c $
 export PYTHONPATH=./
 python tools/train.py --config-file ${CONFIG_PATH} --num-gpus ${NUM_GPU} --options save_path=${SAVE_PATH} resume=True weight=${CHECKPOINT_PATH}
 ```
+**Train on multiple machines.** Run the script on every machine with the same number of machines (`-m`) and the same init URL (`-u`, `tcp://MASTER_ADDR:MASTER_PORT` of machine 0), and a distinct machine rank (`-k`) per machine. Under Slurm both values are derived from `SLURM_NODELIST` / `SLURM_NODEID` automatically; the `DIST_URL` and `MACHINE_RANK` environment variables are honored as well.
+```bash
+# machine 0
+sh scripts/train.sh -p ${INTERPRETER_PATH} -g ${NUM_GPU} -m 2 -k 0 -u tcp://${MASTER_ADDR}:${MASTER_PORT} -d ${DATASET_NAME} -c ${CONFIG_NAME} -n ${EXP_NAME}
+# machine 1
+sh scripts/train.sh -p ${INTERPRETER_PATH} -g ${NUM_GPU} -m 2 -k 1 -u tcp://${MASTER_ADDR}:${MASTER_PORT} -d ${DATASET_NAME} -c ${CONFIG_NAME} -n ${EXP_NAME}
+```
 **Weights and Biases.**
 Pointcept by default enables both `tensorboard` and `wandb`. There are some usage notes related to `wandb`:
 1. Disable by set `enable_wandb=False`;

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,9 +11,10 @@ EXP_NAME=debug
 WEIGHT=model_best
 NUM_GPU=None
 NUM_MACHINE=1
-DIST_URL="auto"
+MACHINE_RANK=${MACHINE_RANK:-${SLURM_NODEID:-0}}
+DIST_URL=${DIST_URL:-auto}
 
-while getopts "p:d:c:n:w:g:m:" opt; do
+while getopts "p:d:c:n:w:g:m:k:u:" opt; do
   case $opt in
     p)
       PYTHON=$OPTARG
@@ -36,6 +37,12 @@ while getopts "p:d:c:n:w:g:m:" opt; do
     m)
       NUM_MACHINE=$OPTARG
       ;;
+    k)
+      MACHINE_RANK=$OPTARG
+      ;;
+    u)
+      DIST_URL=$OPTARG
+      ;;
     \?)
       echo "Invalid option: -$OPTARG"
       ;;
@@ -52,8 +59,9 @@ echo "Python interpreter dir: $PYTHON"
 echo "Dataset: $DATASET"
 echo "GPU Num: $NUM_GPU"
 echo "Machine Num: $NUM_MACHINE"
+echo "Machine Rank: $MACHINE_RANK"
 
-if [ -n "$SLURM_NODELIST" ]; then
+if [ -n "$SLURM_NODELIST" ] && [ "$DIST_URL" = "auto" ]; then
   MASTER_HOSTNAME=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
   MASTER_ADDR=$(getent hosts "$MASTER_HOSTNAME" | awk '{ print $1 }')
   MASTER_PORT=$((10000 + 0x$(echo -n "${DATASET}/${EXP_NAME}" | md5sum | cut -c 1-4 | awk '{print $1}') % 20000))
@@ -61,6 +69,11 @@ if [ -n "$SLURM_NODELIST" ]; then
 fi
 
 echo "Dist URL: $DIST_URL"
+
+if [ "$NUM_MACHINE" -gt 1 ] && [ "$DIST_URL" = "auto" ]; then
+  echo "Error: dist url auto only works on a single machine; for -m $NUM_MACHINE pass -u tcp://MASTER_ADDR:MASTER_PORT (or set DIST_URL) on every machine" >&2
+  exit 1
+fi
 
 EXP_DIR=exp/${DATASET}/${EXP_NAME}
 MODEL_DIR=${EXP_DIR}/model
@@ -87,6 +100,6 @@ $PYTHON -u tools/$TEST_CODE \
   --config-file "$CONFIG_DIR" \
   --num-gpus "$NUM_GPU" \
   --num-machines "$NUM_MACHINE" \
-  --machine-rank ${SLURM_NODEID:-0} \
+  --machine-rank "$MACHINE_RANK" \
   --dist-url ${DIST_URL} \
   --options save_path="$EXP_DIR" weight="${MODEL_DIR}"/"${WEIGHT}".pth

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -13,10 +13,11 @@ WEIGHT="None"
 RESUME=false
 NUM_GPU=None
 NUM_MACHINE=1
-DIST_URL="auto"
+MACHINE_RANK=${MACHINE_RANK:-${SLURM_NODEID:-0}}
+DIST_URL=${DIST_URL:-auto}
 
 
-while getopts "p:d:c:n:w:g:m:r:" opt; do
+while getopts "p:d:c:n:w:g:m:k:u:r:" opt; do
   case $opt in
     p)
       PYTHON=$OPTARG
@@ -42,6 +43,12 @@ while getopts "p:d:c:n:w:g:m:r:" opt; do
     m)
       NUM_MACHINE=$OPTARG
       ;;
+    k)
+      MACHINE_RANK=$OPTARG
+      ;;
+    u)
+      DIST_URL=$OPTARG
+      ;;
     \?)
       echo "Invalid option: -$OPTARG"
       ;;
@@ -59,8 +66,9 @@ echo "Dataset: $DATASET"
 echo "Config: $CONFIG"
 echo "GPU Num: $NUM_GPU"
 echo "Machine Num: $NUM_MACHINE"
+echo "Machine Rank: $MACHINE_RANK"
 
-if [ -n "$SLURM_NODELIST" ]; then
+if [ -n "$SLURM_NODELIST" ] && [ "$DIST_URL" = "auto" ]; then
   MASTER_HOSTNAME=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
   MASTER_ADDR=$(getent hosts "$MASTER_HOSTNAME" | awk '{ print $1 }')
   MASTER_PORT=$((10000 + 0x$(echo -n "${DATASET}/${EXP_NAME}" | md5sum | cut -c 1-4 | awk '{print $1}') % 20000))
@@ -68,6 +76,11 @@ if [ -n "$SLURM_NODELIST" ]; then
 fi
 
 echo "Dist URL: $DIST_URL"
+
+if [ "$NUM_MACHINE" -gt 1 ] && [ "$DIST_URL" = "auto" ]; then
+  echo "Error: dist url auto only works on a single machine; for -m $NUM_MACHINE pass -u tcp://MASTER_ADDR:MASTER_PORT (or set DIST_URL) on every machine" >&2
+  exit 1
+fi
 
 EXP_DIR=exp/${DATASET}/${EXP_NAME}
 MODEL_DIR=${EXP_DIR}/model
@@ -100,7 +113,7 @@ then
     --config-file "$CONFIG_DIR" \
     --num-gpus "$NUM_GPU" \
     --num-machines "$NUM_MACHINE" \
-    --machine-rank ${SLURM_NODEID:-0} \
+    --machine-rank "$MACHINE_RANK" \
     --dist-url ${DIST_URL} \
     --options save_path="$EXP_DIR"
 else
@@ -108,7 +121,7 @@ else
     --config-file "$CONFIG_DIR" \
     --num-gpus "$NUM_GPU" \
     --num-machines "$NUM_MACHINE" \
-    --machine-rank ${SLURM_NODEID:-0} \
+    --machine-rank "$MACHINE_RANK" \
     --dist-url ${DIST_URL} \
     --options save_path="$EXP_DIR" resume="$RESUME" weight="$WEIGHT"
 fi

--- a/tests/test_launch_scripts.py
+++ b/tests/test_launch_scripts.py
@@ -62,7 +62,9 @@ class LaunchScriptTestCase(unittest.TestCase):
         )
 
     def launch_argv(self, result):
-        lines = [l for l in result.stdout.splitlines() if l.startswith("STUB_ARGV ")]
+        lines = [
+            line for line in result.stdout.splitlines() if line.startswith("STUB_ARGV ")
+        ]
         self.assertEqual(len(lines), 1, result.stdout + result.stderr)
         return lines[0]
 
@@ -99,6 +101,14 @@ class LaunchScriptTestCase(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("--machine-rank 3", self.launch_argv(result))
 
+    def check_slurm_explicit_url_wins(self, name):
+        env = {"SLURM_NODELIST": "node[1-2]", "SLURM_NODEID": "1"}
+        result = self.run_script(name, "-m", "2", "-u", "tcp://10.0.0.1:29500", env=env)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        argv = self.launch_argv(result)
+        self.assertIn("--machine-rank 1", argv)
+        self.assertIn("--dist-url tcp://10.0.0.1:29500", argv)
+
     def check_multi_machine_without_url_fails(self, name):
         result = self.run_script(name, "-m", "2")
         self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
@@ -119,6 +129,9 @@ class LaunchScriptTestCase(unittest.TestCase):
     def test_train_slurm_node_id_rank(self):
         self.check_slurm_node_id_rank("train.sh")
 
+    def test_train_slurm_explicit_url_wins(self):
+        self.check_slurm_explicit_url_wins("train.sh")
+
     def test_train_multi_machine_without_url_fails(self):
         self.check_multi_machine_without_url_fails("train.sh")
 
@@ -133,6 +146,9 @@ class LaunchScriptTestCase(unittest.TestCase):
 
     def test_test_slurm_node_id_rank(self):
         self.check_slurm_node_id_rank("test.sh")
+
+    def test_test_slurm_explicit_url_wins(self):
+        self.check_slurm_explicit_url_wins("test.sh")
 
     def test_test_multi_machine_without_url_fails(self):
         self.check_multi_machine_without_url_fails("test.sh")

--- a/tests/test_launch_scripts.py
+++ b/tests/test_launch_scripts.py
@@ -1,0 +1,142 @@
+"""
+Tests for scripts/train.sh and scripts/test.sh.
+
+The scripts are exercised in a temporary copy of the repository layout with a
+stub interpreter that echoes its argv, so no GPU, torch or cluster is needed.
+
+Run with: python -m unittest tests/test_launch_scripts.py
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STUB = '#!/bin/sh\necho "STUB_ARGV $*"\n'
+
+
+class LaunchScriptTestCase(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="pointcept-scripts-")
+        for name in ("scripts", "tools", "pointcept"):
+            os.makedirs(os.path.join(self.root, name))
+        for name in ("train.sh", "test.sh"):
+            shutil.copy(
+                os.path.join(REPO_ROOT, "scripts", name),
+                os.path.join(self.root, "scripts", name),
+            )
+        self.stub = os.path.join(self.root, "stub_python")
+        with open(self.stub, "w") as f:
+            f.write(STUB)
+        os.chmod(self.stub, os.stat(self.stub).st_mode | stat.S_IEXEC)
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def run_script(self, name, *args, env=None):
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.startswith("SLURM_") and k not in ("DIST_URL", "MACHINE_RANK")
+        }
+        clean_env.update(env or {})
+        cmd = [
+            "sh",
+            os.path.join(self.root, "scripts", name),
+            "-p",
+            self.stub,
+            "-g",
+            "1",
+            "-d",
+            "dataset",
+            "-c",
+            "config",
+            "-n",
+            "exp",
+        ] + list(args)
+        return subprocess.run(
+            cmd, cwd=self.root, env=clean_env, capture_output=True, text=True
+        )
+
+    def launch_argv(self, result):
+        lines = [l for l in result.stdout.splitlines() if l.startswith("STUB_ARGV ")]
+        self.assertEqual(len(lines), 1, result.stdout + result.stderr)
+        return lines[0]
+
+    def check_single_machine_default(self, name):
+        result = self.run_script(name)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        argv = self.launch_argv(result)
+        self.assertIn("--num-machines 1", argv)
+        self.assertIn("--machine-rank 0", argv)
+        self.assertIn("--dist-url auto", argv)
+
+    def check_multi_machine_flags(self, name):
+        result = self.run_script(
+            name, "-m", "2", "-u", "tcp://10.0.0.1:29500", "-k", "1"
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        argv = self.launch_argv(result)
+        self.assertIn("--num-machines 2", argv)
+        self.assertIn("--machine-rank 1", argv)
+        self.assertIn("--dist-url tcp://10.0.0.1:29500", argv)
+
+    def check_multi_machine_env(self, name):
+        env = {"DIST_URL": "tcp://10.0.0.2:29501", "MACHINE_RANK": "1"}
+        result = self.run_script(name, "-m", "2", env=env)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        argv = self.launch_argv(result)
+        self.assertIn("--machine-rank 1", argv)
+        self.assertIn("--dist-url tcp://10.0.0.2:29501", argv)
+
+    def check_slurm_node_id_rank(self, name):
+        result = self.run_script(
+            name, "-m", "2", "-u", "tcp://10.0.0.1:29500", env={"SLURM_NODEID": "3"}
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("--machine-rank 3", self.launch_argv(result))
+
+    def check_multi_machine_without_url_fails(self, name):
+        result = self.run_script(name, "-m", "2")
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("-u", result.stderr)
+        self.assertIn("DIST_URL", result.stderr)
+        self.assertNotIn("STUB_ARGV", result.stdout)
+        self.assertFalse(os.path.exists(os.path.join(self.root, "exp")))
+
+    def test_train_single_machine_default(self):
+        self.check_single_machine_default("train.sh")
+
+    def test_train_multi_machine_flags(self):
+        self.check_multi_machine_flags("train.sh")
+
+    def test_train_multi_machine_env(self):
+        self.check_multi_machine_env("train.sh")
+
+    def test_train_slurm_node_id_rank(self):
+        self.check_slurm_node_id_rank("train.sh")
+
+    def test_train_multi_machine_without_url_fails(self):
+        self.check_multi_machine_without_url_fails("train.sh")
+
+    def test_test_single_machine_default(self):
+        self.check_single_machine_default("test.sh")
+
+    def test_test_multi_machine_flags(self):
+        self.check_multi_machine_flags("test.sh")
+
+    def test_test_multi_machine_env(self):
+        self.check_multi_machine_env("test.sh")
+
+    def test_test_slurm_node_id_rank(self):
+        self.check_slurm_node_id_rank("test.sh")
+
+    def test_test_multi_machine_without_url_fails(self):
+        self.check_multi_machine_without_url_fails("test.sh")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`scripts/train.sh` and `scripts/test.sh` accept `-m NUM_MACHINE`, but there is no way to pass the distributed init URL or the machine rank. Outside Slurm (plain SSH on two hosts, a Kubernetes JobSet, etc.) `sh scripts/train.sh -m 2 ...` always launches `tools/train.py` with `--dist-url auto --machine-rank 0`, and `pointcept/engines/launch.py` aborts with:

```
AssertionError: dist_url=auto not supported in multi-machine jobs.
```

`tools/train.py` / `tools/test.py` already expose `--dist-url` and `--machine-rank` (`pointcept/engines/defaults.py:86-99`), so the limitation is only in the launch scripts. This is what issue #370 asks about; the multi-machine handling in the script pasted there (`DIST_URL="auto"`, `--machine-rank ${SLURM_NODEID:-0}`) is unchanged on `main`.

## Root cause

- `scripts/train.sh:16` hard-codes `DIST_URL="auto"`; the only code path that changes it is the `if [ -n "$SLURM_NODELIST" ]` block at `scripts/train.sh:63-68`.
- `scripts/train.sh:103` and `:111` pass `--machine-rank ${SLURM_NODEID:-0}`, so every non-Slurm machine gets rank 0.
- The `getopts` string at `scripts/train.sh:19` has no option for either value.
- `scripts/test.sh:14`, `:56-61`, `:90` have the identical pattern.
- `pointcept/engines/launch.py:62-65` asserts `num_machines == 1` when `dist_url == "auto"`, so the script can never succeed with `-m 2` off Slurm.

## Fix

- Add `-u DIST_URL` and `-k MACHINE_RANK` options to both scripts, with `DIST_URL` / `MACHINE_RANK` environment variables as fallbacks (`MACHINE_RANK` still defaults to `${SLURM_NODEID:-0}`).
- Keep the Slurm derivation of the URL, but only when no URL was given (`DIST_URL` still `auto`), so an explicit `-u` wins inside Slurm as well.
- Fail early, before the experiment directory is created, when `-m` is greater than 1 and the URL is still `auto`, with a message pointing at `-u` / `DIST_URL` instead of the assertion deep in `launch.py`.
- Pass `--machine-rank "$MACHINE_RANK"` to `train.py` / `test.py`.
- README: short "Train on multiple machines" example next to the existing training examples.

Single-machine invocations are unchanged (`--num-machines 1 --machine-rank 0 --dist-url auto`), and the Slurm path is unchanged when `-u` is not given.

## How tested

`tests/test_launch_scripts.py` (stdlib `unittest`, also discoverable by `pytest`) copies the two scripts into a temporary repo layout and runs them with a stub interpreter that echoes its argv, so no GPU, torch, or cluster is needed. It checks, for each script: the single-machine default argv, `-m 2 -u ... -k 1` reaching the Python argv, `DIST_URL` / `MACHINE_RANK` env fallbacks, `SLURM_NODEID` still used as the default rank, and a non-zero exit with no `exp/` directory when `-m 2` is used without a URL.

Before the fix (`python3 -m unittest tests/test_launch_scripts.py` on `main` + the new test):

```
FAIL: test_train_multi_machine_flags
AssertionError: '--machine-rank 1' not found in 'STUB_ARGV exp/dataset/exp/code/tools/train.py --config-file configs/dataset/config.py --num-gpus 1 --num-machines 2 --machine-rank 0 --dist-url auto --options save_path=exp/dataset/exp'

FAIL: test_train_multi_machine_without_url_fails
AssertionError: 0 == 0 : ...
STUB_ARGV exp/dataset/exp/code/tools/train.py ... --num-machines 2 --machine-rank 0 --dist-url auto ...

Ran 12 tests in 0.063s
FAILED (failures=8)
```

After the fix:

```
Ran 12 tests in 0.054s
OK
```

Also `sh -n` / `bash -n` on both scripts (the box's `/bin/sh` is dash), and `black --check` on the new test file.

## Links

- https://github.com/Pointcept/Pointcept/issues/370

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.

